### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Xinabox
 maintainer= xinabox <support@xinabox.cc>
 sentence=
 paragraph=
-category=Output
+category=Display
 url=https://github.com/xinabox/arduino-OD22
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Output' in library arduino-OD22 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format